### PR TITLE
Fix: Use eAPI connection instead of SSH

### DIFF
--- a/labs/lab01-ansible-basics/README.md
+++ b/labs/lab01-ansible-basics/README.md
@@ -60,26 +60,28 @@ $ ansible Leaf1 -m debug -a "var=hostvars[inventory_hostname]"
 $ ansible-inventory --host Leaf1
 ```
 
+> Update `inventory.yml` with the generated password of your ATD instance
+
 __4. Run Ad-hoc commands and analyse the differences__
 
 ```shell
 # Run show version on Spine1
-$ ansible Spine1 -m raw -a "show version | grep image " -u arista -k
+$ ansible Spine1 -m eos_command -a "commands='show version | grep image'"
 
 # Run show version on Spine1 with JSON output
-$ ansible Spine1 -m raw -a "show version | json " -u arista -k
-
+$ ansible Spine1 -m eos_command -a "commands='show version | json'"
 # Run show run on all the switches of the DC
-$ ansible DC -m raw -a "show runn" -u arista -k
+$ ansible DC -m eos_command -a "commands='show runn'"
 
 # Run show run on Spine1 only by using the command option --limit
-$ ansible DC --limit Spine1 -m raw -a "show runn" -u arista -k
+$ ansible DC --limit Spine1 -m eos_command -a "commands='show runn'"
 
-# Run show version on the Spine switches using another inventory, in this case using Test_inventory.yml
-$ ansible DC_SPINES -i Test_inventory.yml -m raw -a "show version | grep image" -u arista -k
+# Run show version on the Spine switches using another inventory, in this case using inventory_cli.yml
+# Note that inventory_cli uses a different connection method to the switches : CLI over SSH
+$ ansible DC_SPINES -i inventory_cli.yml -m eos_command -a "commands='show version | grep image'"
 
 # Run show version on the Spine switches using Test_inventory.yml and the verbose mode
-$ ansible DC -i Test_inventory.yml -m raw -a "show version | grep image" -u arista -vvv -k
+$ ansible DC -i inventory_cli.yml -m eos_command -a "commands='show version | grep image'" -vvv
 ```
 
 __5. Use playbooks to collect EOS version and to configure__
@@ -101,7 +103,7 @@ $ ansible-playbook --limit DC_SPINES -i Test_inventory.yml playbook.eos_version.
 $ ansible-playbook playbook.ethernet_descr.yml
 
 # Use an ansible raw command to verify that the configuration has been applied
-$ ansible Leaf1 -m raw -a "show running interface Ethernet1" -u arista
+$ ansible Leaf1 -m eos_command -a "show running interface Ethernet1"
 ```
 
 __6. Create simple playbooks__
@@ -118,12 +120,7 @@ $ more playbook.vlan.yml
 ---
 - name: Configure vlan 100
   hosts: DC_LEAFS
-  connection: network_cli
-  gather_facts: no
-  vars:
-    ansible_network_os: eos
-    ansible_become: yes
-    ansible_become_method: enable
+  gather_facts: false
   tasks:
     - name: Configure vlan 100 on Leaf switches
       eos_config:

--- a/labs/lab01-ansible-basics/ansible.cfg
+++ b/labs/lab01-ansible-basics/ansible.cfg
@@ -1,5 +1,4 @@
 [defaults]
-host_key_checking = False
 inventory = inventory.yml
 gathering = explicit
 retry_files_enabled = False

--- a/labs/lab01-ansible-basics/group_vars/DC.yml
+++ b/labs/lab01-ansible-basics/group_vars/DC.yml
@@ -1,9 +1,5 @@
 # Validation lab
 
-# Ansible user and password
-ansible_user: arista
-ansible_password: arista
-
 # local users
 local_users:
   admin:

--- a/labs/lab01-ansible-basics/inventory.yml
+++ b/labs/lab01-ansible-basics/inventory.yml
@@ -2,6 +2,14 @@
 DC:
   children:
     DC_FABRIC:
+      vars:
+        ansible_network_os: eos
+        ansible_connection: httpapi
+        ansible_httpapi_user: arista
+        ansible_httpapi_password: YOUR_ATD_PASSWORD
+        ansible_httpapi_use_ssl: True
+        ansible_httpapi_validate_certs: False
+        ansible_httpapi_port: 443
       children:
         DC_SPINES:
           hosts:

--- a/labs/lab01-ansible-basics/inventory_cli.yml
+++ b/labs/lab01-ansible-basics/inventory_cli.yml
@@ -2,6 +2,13 @@
 DC:
   children:
     DC_FABRIC:
+      vars:
+        ansible_network_os: eos
+        ansible_connection: network_cli
+        ansible_user: arista
+        ansible_private_key_file: /home/arista/.ssh/id_rsa
+        ansible_become: yes
+        ansible_become_method: enable
       children:
         DC_SPINES:
           hosts:

--- a/labs/lab01-ansible-basics/playbook.eos_version.yml
+++ b/labs/lab01-ansible-basics/playbook.eos_version.yml
@@ -1,11 +1,6 @@
 - name: Collect EOS version
   hosts: DC
-  connection: network_cli
-  gather_facts: no
-  vars:
-    ansible_network_os: eos
-    ansible_become: yes
-    ansible_become_method: enable
+  gather_facts: false
   tasks:
     - name: Get switch EOS version
       eos_command:

--- a/labs/lab01-ansible-basics/playbook.ethernet_descr.yml
+++ b/labs/lab01-ansible-basics/playbook.ethernet_descr.yml
@@ -1,13 +1,7 @@
 ---
 - name: Configure description on Ethernet1
   hosts: Leaf1
-  connection: network_cli
   gather_facts: false
-  vars:
-    ansible_network_os: eos
-    ansible_become: yes
-    ansible_become_method: enable
-
   tasks:
     - name: Configure description on Ethernet1
       eos_config:

--- a/labs/lab01-ansible-basics/playbook.example.lldp.neighbors.yml
+++ b/labs/lab01-ansible-basics/playbook.example.lldp.neighbors.yml
@@ -1,13 +1,7 @@
 ---
 - name: Run commands on remote EOS devices and save the output
   hosts: DC_FABRIC
-  connection: network_cli
   gather_facts: false
-  vars:
-    ansible_network_os: eos
-    ansible_become: yes
-    ansible_become_method: enable
-
   tasks:
     - name: run show command on remote EOS devices
       eos_command:


### PR DESCRIPTION
The following error when playing the lab: `ansible.module_utils.connection.ConnectionError: Failed to authenticate: Bad authentication type; allowed types: ['publickey', 'keyboard-interactive']`

EOS only supports keyboard-interactive or public key auth when using SSH by default (and considering the provisioned config on ATD). I haven't find any knob to use keyboard-interactive with netcommon and the devbox public key is provisioned on the switches anyway.

The alternative is to use eAPI using the correct variables.

Still using CLI over SSH in the `inventory_cli.yml` file and using it with a few commands