### PR TITLE
changing default interpreter to python3 to fix issues where ansible c…

### DIFF
--- a/labs/inventory.yml
+++ b/labs/inventory.yml
@@ -14,4 +14,4 @@ all:
           ansible_network_os: eos
           ansible_httpapi_port: 443
           # Configuration to get Virtual Env information
-          ansible_python_interpreter: $(which python)
+          ansible_python_interpreter: $(which python3)


### PR DESCRIPTION
…annot use the plugins
when leaving the default python interpreter to `$(which python)` ansible can choose python2 in which case playbooks can fail with something like:

```
fatal: [CloudVision]: FAILED! => {"changed": false, "module_stderr": "/bin/sh: 1: /home/coder/.ansible/tmp/ansible-local-816_i7okg4s/ansible-tmp-1642445832.554339-822-12994943389065/AnsiballZ_cv_configlet_v3.py: not found\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 127}
```

changing it to `$(which python3)` fixes this