### PR TITLE
Update required ansible version for CVE-2021-3583

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=2.10,<2.11
+ansible>=4.2.0
 requests==2.22.0
 treelib==1.5.5
 netaddr==0.7.19


### PR DESCRIPTION
dependabot found `CVE-2021-3583` which was fixed in ansible 4.2.0+